### PR TITLE
Make `appdmg` optional dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^14.4.3",
-        "appdmg": "^0.6.4",
         "concurrently": "^7.5.0",
         "cross-env": "^7.0.3",
         "nw": "0.70.1-sdk",
@@ -36,6 +35,9 @@
         "react-scripts": "5.0.1",
         "wait-on": "^6.0.1",
         "web-vitals": "^3.1.0"
+      },
+      "optionalDependencies": {
+        "appdmg": "^0.6.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -7552,7 +7554,7 @@
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.6.4.tgz",
       "integrity": "sha512-YTilgNF0DF2DSRzGzzGDxaTMLXlhe3b3HB8RAaoJJ/VJXZbOlzIAcZ7gdPniHUVUuHjGwnS7fUMd4FvO2Rp94A==",
-      "dev": true,
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -7580,13 +7582,13 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
-      "dev": true
+      "optional": true
     },
     "node_modules/appdmg/node_modules/cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -7602,7 +7604,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "cross-spawn": "^6.0.0",
         "get-stream": "^4.0.0",
@@ -7620,7 +7622,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -7632,7 +7634,7 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
       "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
-      "dev": true,
+      "optional": true,
       "bin": {
         "image-size": "bin/image-size.js"
       },
@@ -7644,7 +7646,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "path-key": "^2.0.0"
       },
@@ -7656,7 +7658,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -7665,7 +7667,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -7677,7 +7679,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7686,7 +7688,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -8497,7 +8499,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.2.0.tgz",
       "integrity": "sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "to-data-view": "^1.1.0"
       }
@@ -8841,7 +8843,7 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
       "integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "stream-buffers": "~2.2.0"
       }
@@ -11505,7 +11507,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
       "integrity": "sha512-kY21M6Lz+76OS3bnCzjdsJSF7LBpLYGCVfavW8TgQD2XkcqIZ86W0y9qUDZu6fp7SIZzqosMDW2zi7zVFfv4hw==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "bplist-creator": "~0.0.3",
         "macos-alias": "~0.2.5",
@@ -13431,7 +13433,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
       "integrity": "sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "imul": "^1.0.0"
       }
@@ -13701,7 +13703,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.2.1.tgz",
       "integrity": "sha512-okTwLB7/Qsq82G6iN5zZJFsOfZtx2/pqrA7Hk/9fvy+c+eJS9CvgGXT2uNxwnI14BDY9L/jQPkaBgSvlKfSW9w==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "random-path": "^0.1.0"
       }
@@ -13710,8 +13712,8 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/fs-xattr/-/fs-xattr-0.3.1.tgz",
       "integrity": "sha512-UVqkrEW0GfDabw4C3HOrFlxKfx0eeigfRne69FxSBdHIP8Qt5Sq6Pu3RM9KmMlkygtC4pPKkj5CiPO5USnj2GA==",
-      "dev": true,
       "hasInstallScript": true,
+      "optional": true,
       "os": [
         "!win32"
       ],
@@ -13773,7 +13775,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "is-property": "^1.0.2"
       }
@@ -13782,7 +13784,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "is-property": "^1.0.0"
       }
@@ -14833,7 +14835,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
       "integrity": "sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15209,13 +15211,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
       "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
-      "dev": true
+      "optional": true
     },
     "node_modules/is-my-json-valid": {
       "version": "2.20.6",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
       "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
@@ -15335,7 +15337,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "dev": true
+      "optional": true
     },
     "node_modules/is-redirect": {
       "version": "1.0.0",
@@ -18151,7 +18153,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
       "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18752,8 +18754,8 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.11.tgz",
       "integrity": "sha512-zIUs3+qpml+w3wiRuADutd7XIO8UABqksot10Utl/tji4UxZzLG4fWDC+yJZoO8/Ehg5RqsvSRE/6TS5AEOeWw==",
-      "dev": true,
       "hasInstallScript": true,
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -20016,7 +20018,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.2.0.tgz",
       "integrity": "sha512-ZkcWZudylwF+ir3Ld1n7gL6bI2mQAzXvSobPwVtu8aYi2sbXeipeSkdcanRLzIofLcM5F53lGaKm2dk7orBi7Q==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "encode-utf8": "^1.0.3",
         "fmix": "^0.1.0",
@@ -20027,7 +20029,7 @@
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
       "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
-      "dev": true
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -20988,7 +20990,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
       "integrity": "sha512-fuDHYgFHJGbpGMgw9skY/bj3HL/Jrn4l/5rSspy00DoT4RyLnDcRvPxdZ+r6OFwIsgAuhDh4I09tAId4mI12bw==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "color-convert": "~0.5.0"
       }
@@ -20997,7 +20999,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
       "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==",
-      "dev": true
+      "optional": true
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -23036,7 +23038,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.2.tgz",
       "integrity": "sha512-4jY0yoEaQ5v9StCl5kZbNIQlg1QheIDBrdkDn53EynpPb9FgO6//p3X/tgMnrC45XN6QZCzU1Xz/+pSSsJBpRw==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "base32-encode": "^0.1.0 || ^1.0.0",
         "murmur-32": "^0.1.0 || ^0.2.0"
@@ -25635,7 +25637,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">= 0.10.0"
       }
@@ -26693,7 +26695,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
       "integrity": "sha512-DbplOfQFkqG5IHcDyyrs/lkvSr3mPUVsFf/RbDppOshs22yTPnSJWEe6FkYd1txAwU/zcnR905ar2fi4kwF29w==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "unorm": "^1.4.1"
       },
@@ -26711,7 +26713,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
       "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ==",
-      "dev": true
+      "optional": true
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -27156,7 +27158,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
       "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -34406,7 +34408,7 @@
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.6.4.tgz",
       "integrity": "sha512-YTilgNF0DF2DSRzGzzGDxaTMLXlhe3b3HB8RAaoJJ/VJXZbOlzIAcZ7gdPniHUVUuHjGwnS7fUMd4FvO2Rp94A==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "async": "^1.4.2",
         "ds-store": "^0.1.5",
@@ -34425,13 +34427,13 @@
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
-          "dev": true
+          "optional": true
         },
         "cross-spawn": {
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "nice-try": "^1.0.4",
             "path-key": "^2.0.1",
@@ -34444,7 +34446,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "cross-spawn": "^6.0.0",
             "get-stream": "^4.0.0",
@@ -34459,7 +34461,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "pump": "^3.0.0"
           }
@@ -34468,13 +34470,13 @@
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
           "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
-          "dev": true
+          "optional": true
         },
         "npm-run-path": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "path-key": "^2.0.0"
           }
@@ -34483,13 +34485,13 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-          "dev": true
+          "optional": true
         },
         "shebang-command": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
           "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "shebang-regex": "^1.0.0"
           }
@@ -34498,13 +34500,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-          "dev": true
+          "optional": true
         },
         "which": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -35154,7 +35156,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.2.0.tgz",
       "integrity": "sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "to-data-view": "^1.1.0"
       }
@@ -35438,7 +35440,7 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
       "integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "stream-buffers": "~2.2.0"
       }
@@ -37504,7 +37506,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
       "integrity": "sha512-kY21M6Lz+76OS3bnCzjdsJSF7LBpLYGCVfavW8TgQD2XkcqIZ86W0y9qUDZu6fp7SIZzqosMDW2zi7zVFfv4hw==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "bplist-creator": "~0.0.3",
         "macos-alias": "~0.2.5",
@@ -39006,7 +39008,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
       "integrity": "sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "imul": "^1.0.0"
       }
@@ -39202,7 +39204,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.2.1.tgz",
       "integrity": "sha512-okTwLB7/Qsq82G6iN5zZJFsOfZtx2/pqrA7Hk/9fvy+c+eJS9CvgGXT2uNxwnI14BDY9L/jQPkaBgSvlKfSW9w==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "random-path": "^0.1.0"
       }
@@ -39211,7 +39213,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/fs-xattr/-/fs-xattr-0.3.1.tgz",
       "integrity": "sha512-UVqkrEW0GfDabw4C3HOrFlxKfx0eeigfRne69FxSBdHIP8Qt5Sq6Pu3RM9KmMlkygtC4pPKkj5CiPO5USnj2GA==",
-      "dev": true
+      "optional": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -39251,7 +39253,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "is-property": "^1.0.2"
       }
@@ -39260,7 +39262,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "is-property": "^1.0.0"
       }
@@ -40051,7 +40053,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
       "integrity": "sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==",
-      "dev": true
+      "optional": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -40329,13 +40331,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
       "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
-      "dev": true
+      "optional": true
     },
     "is-my-json-valid": {
       "version": "2.20.6",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
       "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
@@ -40419,7 +40421,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "dev": true
+      "optional": true
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -42698,7 +42700,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
       "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
-      "dev": true
+      "devOptional": true
     },
     "jsx-ast-utils": {
       "version": "3.3.3",
@@ -43214,7 +43216,7 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.11.tgz",
       "integrity": "sha512-zIUs3+qpml+w3wiRuADutd7XIO8UABqksot10Utl/tji4UxZzLG4fWDC+yJZoO8/Ehg5RqsvSRE/6TS5AEOeWw==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "nan": "^2.4.0"
       }
@@ -44275,7 +44277,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.2.0.tgz",
       "integrity": "sha512-ZkcWZudylwF+ir3Ld1n7gL6bI2mQAzXvSobPwVtu8aYi2sbXeipeSkdcanRLzIofLcM5F53lGaKm2dk7orBi7Q==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "encode-utf8": "^1.0.3",
         "fmix": "^0.1.0",
@@ -44286,7 +44288,7 @@
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
       "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
-      "dev": true
+      "optional": true
     },
     "nanoid": {
       "version": "3.3.4",
@@ -45016,7 +45018,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
       "integrity": "sha512-fuDHYgFHJGbpGMgw9skY/bj3HL/Jrn4l/5rSspy00DoT4RyLnDcRvPxdZ+r6OFwIsgAuhDh4I09tAId4mI12bw==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "color-convert": "~0.5.0"
       },
@@ -45025,7 +45027,7 @@
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
           "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==",
-          "dev": true
+          "optional": true
         }
       }
     },
@@ -46368,7 +46370,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.2.tgz",
       "integrity": "sha512-4jY0yoEaQ5v9StCl5kZbNIQlg1QheIDBrdkDn53EynpPb9FgO6//p3X/tgMnrC45XN6QZCzU1Xz/+pSSsJBpRw==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "base32-encode": "^0.1.0 || ^1.0.0",
         "murmur-32": "^0.1.0 || ^0.2.0"
@@ -48438,7 +48440,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
-      "dev": true
+      "optional": true
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -49273,7 +49275,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
       "integrity": "sha512-DbplOfQFkqG5IHcDyyrs/lkvSr3mPUVsFf/RbDppOshs22yTPnSJWEe6FkYd1txAwU/zcnR905ar2fi4kwF29w==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "unorm": "^1.4.1"
       }
@@ -49288,7 +49290,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
       "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ==",
-      "dev": true
+      "optional": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -49634,7 +49636,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
       "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
-      "dev": true
+      "optional": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^14.4.3",
-    "appdmg": "^0.6.4",
     "concurrently": "^7.5.0",
     "cross-env": "^7.0.3",
     "nw": "0.70.1-sdk",
@@ -47,6 +46,9 @@
     "react-router-dom": "^6.4.3",
     "react-spring": "^9.5.4",
     "zxcvbn": "^4.4.2"
+  },
+  "optionalDependencies": {
+    "appdmg": "^0.6.4"
   },
   "build": {
     "manifestProps": [


### PR DESCRIPTION
I'm running Ubuntu 20 and running `npm install` does not work since `appdmg` requires MacOS.